### PR TITLE
common: fix compile error in Ubuntu 22.04.2 LTS

### DIFF
--- a/help.c
+++ b/help.c
@@ -63,6 +63,7 @@ static void monitors_help(struct help_ctx *ctx)
 static void print_events_format(struct help_ctx *ctx)
 {
     int i, j;
+    int ret;
     char path[256];
     char *format;
     size_t size;
@@ -73,8 +74,10 @@ static void print_events_format(struct help_ctx *ctx)
             printf("%s:%s\n", tp->sys, tp->name);
             snprintf(path, sizeof(path), "kernel/debug/tracing/events/%s/%s/format", tp->sys, tp->name);
             if (sysfs__read_str(path, &format, &size) == 0) {
-                write(STDOUT_FILENO, format, size);
+                ret = write(STDOUT_FILENO, format, size);
                 free(format);
+                if (ret == -1)
+                    return;
             }
             printf("\n");
         }

--- a/monitor.c
+++ b/monitor.c
@@ -1139,7 +1139,8 @@ int main(int argc, char *argv[])
     // workload output to stdout & stderr
     // perf-prof output to env.output file
     if (env.output) {
-        freopen(env.output, "w+", stdout);
+        if (!freopen(env.output, "w+", stdout))
+            return -1;
         dup2(STDOUT_FILENO, STDERR_FILENO);
     }
 


### PR DESCRIPTION
fix below compile errors:
help.c:76:17: error: ignoring return value of ‘write’ declared with attribute ‘warn_unused_result’ [-Werror=unused-result] monitor.c:1142:9: error: ignoring return value of ‘freopen’ declared with attribute ‘warn_unused_result’ [-Werror=unused-result]